### PR TITLE
Add proptypes to components

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "prop-types": "^15.5.10",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-scripts": "1.0.13"

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -10,21 +10,9 @@ describe('<App />', () => {
     ReactDOM.render(<App />, div);
   });
 
-  describe('component rendering', () => {
-    let app;
-    let boardContainers;
-
-    beforeEach(() => {
-      app = shallow(<App />);
-      boardContainers = app.find(BoardContainer);
-    })
-    
-    it ('renders a board container', () => {
-      expect(boardContainers).toHaveLength(1);
-    });
-
-    it ('passes a dimension to board container', () => {
-      expect(boardContainers.first().prop('dimension')).toBeDefined(); 
-    });
+  it ('renders a board container', () => {
+    const app = shallow(<App />);
+    const boardContainers = app.find(BoardContainer);
+    expect(boardContainers).toHaveLength(1);
   });
 });

--- a/src/Board.js
+++ b/src/Board.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import './Board.css';
 
 function Space(props) {
@@ -41,6 +42,15 @@ class Board extends Component {
     );
   }
 }
+
+Space.propTypes = {
+  handleClick: PropTypes.func.isRequired
+};
+
+Board.propTypes = {
+  dimension: PropTypes.number.isRequired,
+  handleClick: PropTypes.func.isRequired
+};
 
 export {Space};
 export default Board;

--- a/src/Board.test.js
+++ b/src/Board.test.js
@@ -17,23 +17,25 @@ describe('<Board />', () => {
     expect(board.find('div.row')).toHaveLength(dimension);
   });
 
-  it ('renders dimension^2 spaces', () => {
-    expect(board.find(Space)).toHaveLength(dimension*dimension);
-  });
-
-  it ('passes click handler to spaces', () => {
-    expect(board.find(Space).first().prop('handleClick')).toBeDefined();
+  it ('renders dimension spaces in each row', () => {
+    const row = board.find('div.row').first();
+    expect(row.find(Space)).toHaveLength(dimension);
   });
 });
 
 describe('<Space />', () => {
+  let handleClick;
+
+  beforeEach(() => {
+    handleClick = jest.fn();
+  });
+
   it ('renders a button', () => {
-    const space = shallow(<Space />);
+    const space = shallow(<Space handleClick={handleClick}/>);
     expect(space.find('button')).toHaveLength(1);
   });
 
   it ('calls given handler when button clicked', () => {
-    const handleClick = jest.fn();
     const space = shallow(<Space handleClick={handleClick}/>);
     space.find('button').simulate('click');
     expect(handleClick).toHaveBeenCalled();

--- a/src/BoardContainer.js
+++ b/src/BoardContainer.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Board from './Board.js'
 
 class BoardContainer extends Component {
@@ -10,6 +11,10 @@ class BoardContainer extends Component {
   render() {
     return React.createElement(Board, {dimension: this.props.dimension, handleClick: (i) => this.handleClick(i)})
   }
+}
+
+BoardContainer.propTypes = {
+  dimension: PropTypes.number
 }
 
 export default BoardContainer;


### PR DESCRIPTION
This also removes tests that were checking prop type propagation
as proptypes and full app component render should ensure any issues
are caught.